### PR TITLE
Feature/laundry review api

### DIFF
--- a/src/main/java/com/coders/laundry/common/exceptionhandler/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/coders/laundry/common/exceptionhandler/GlobalApiExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.coders.laundry.common.exceptionhandler;
+
+import com.coders.laundry.domain.exceptions.ResourceAlreadyExistsException;
+import com.coders.laundry.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalApiExceptionHandler {
+
+    @ExceptionHandler(ResourceAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> resourceAlreadyExistsException(ResourceAlreadyExistsException e) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+}

--- a/src/main/java/com/coders/laundry/controller/ReviewController.java
+++ b/src/main/java/com/coders/laundry/controller/ReviewController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -21,10 +22,18 @@ public class ReviewController {
 
     private final TokenManagerService tokenManagerService;
 
+    @GetMapping(value = "/laundries/{laundryId}/reviews",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> findLaundryReviewsByLaundryId(@PathVariable Integer laundryId) {
+        List<Review> reviews = reviewService.findAllByLaundryId(laundryId);
+        return ResponseEntity.ok().body(reviews);
+    }
+
     @PostMapping(value = "/laundries/{laundryId}/reviews",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> save(
+    public ResponseEntity<?> uploadLaundryReview(
             @RequestHeader(value = HttpHeaders.AUTHORIZATION) String token,
             @PathVariable Integer laundryId,
             @Valid @RequestBody ReviewUploadRequest reviewUploadRequest
@@ -43,9 +52,9 @@ public class ReviewController {
         }
 
         Integer memberId = tokenManagerService.findMemberId(token);
-        Review createdReview = reviewService.save(memberId, reviewUploadRequest);
+        Review createdReview = reviewService.upload(memberId, reviewUploadRequest);
 
         return ResponseEntity.ok().body(createdReview);
     }
-    
+
 }

--- a/src/main/java/com/coders/laundry/controller/ReviewController.java
+++ b/src/main/java/com/coders/laundry/controller/ReviewController.java
@@ -1,6 +1,8 @@
 package com.coders.laundry.controller;
 
-import com.coders.laundry.dto.*;
+import com.coders.laundry.dto.ErrorResponse;
+import com.coders.laundry.dto.Review;
+import com.coders.laundry.dto.ReviewUploadRequest;
 import com.coders.laundry.service.ReviewService;
 import com.coders.laundry.service.TokenManagerService;
 import lombok.RequiredArgsConstructor;
@@ -62,6 +64,14 @@ public class ReviewController {
                         .buildAndExpand(createdReview.getReviewId())
                         .toUri())
                 .body(createdReview);
+    }
+
+    // TODO Move to global exception handler
+    @ExceptionHandler(RuntimeException.class)
+    private ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(e.getMessage()));
     }
 
 }

--- a/src/main/java/com/coders/laundry/controller/ReviewController.java
+++ b/src/main/java/com/coders/laundry/controller/ReviewController.java
@@ -1,0 +1,51 @@
+package com.coders.laundry.controller;
+
+import com.coders.laundry.dto.*;
+import com.coders.laundry.service.ReviewService;
+import com.coders.laundry.service.TokenManagerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    private final TokenManagerService tokenManagerService;
+
+    @PostMapping(value = "/laundries/{laundryId}/reviews",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> save(
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION) String token,
+            @PathVariable Integer laundryId,
+            @Valid @RequestBody ReviewUploadRequest reviewUploadRequest
+    ) {
+        // TODO verify token value and retrieve user details(ex.memberId) if token is present and validated
+        if (token == null || !tokenManagerService.verify(token)) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorResponse("Please check authorization token value."));
+        }
+
+        if (!laundryId.equals(reviewUploadRequest.getLaundryId())) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(new ErrorResponse("The path variable 'laundryId' is not equals to request body's 'laundryId' parameter"));
+        }
+
+        Integer memberId = tokenManagerService.findMemberId(token);
+        Review createdReview = reviewService.save(memberId, reviewUploadRequest);
+
+        return ResponseEntity.ok().body(createdReview);
+    }
+    
+}

--- a/src/main/java/com/coders/laundry/controller/ReviewController.java
+++ b/src/main/java/com/coders/laundry/controller/ReviewController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -54,7 +55,13 @@ public class ReviewController {
         Integer memberId = tokenManagerService.findMemberId(token);
         Review createdReview = reviewService.upload(memberId, reviewUploadRequest);
 
-        return ResponseEntity.ok().body(createdReview);
+        return ResponseEntity
+                .created(ServletUriComponentsBuilder
+                        .fromCurrentRequest()
+                        .path("/{reviewId}")
+                        .buildAndExpand(createdReview.getReviewId())
+                        .toUri())
+                .body(createdReview);
     }
 
 }

--- a/src/main/java/com/coders/laundry/domain/entity/LaundryEntity.java
+++ b/src/main/java/com/coders/laundry/domain/entity/LaundryEntity.java
@@ -1,5 +1,6 @@
 package com.coders.laundry.domain.entity;
 
+import com.coders.laundry.dto.Laundry;
 import lombok.*;
 
 import java.util.List;
@@ -27,4 +28,22 @@ public class LaundryEntity {
     private List<String> tags;
     private int distance;
     private boolean like;
+
+    public static Laundry toDto(LaundryEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return Laundry.builder()
+                .laundryId(entity.laundryId)
+                .name(entity.name)
+                .jibunAddress(entity.jibunAddress)
+                .jibunAddressDetail(entity.jibunAddressDetail)
+                .doroAddress(entity.doroAddress)
+                .doroAddressDetail(entity.doroAddressDetail)
+                .latitude(entity.latitude)
+                .longitude(entity.longitude)
+                .partnership(entity.partnership)
+                .build();
+    }
 }

--- a/src/main/java/com/coders/laundry/domain/entity/ReviewEntity.java
+++ b/src/main/java/com/coders/laundry/domain/entity/ReviewEntity.java
@@ -1,5 +1,6 @@
 package com.coders.laundry.domain.entity;
 
+import com.coders.laundry.dto.Review;
 import lombok.Builder;
 import lombok.Data;
 
@@ -26,5 +27,18 @@ public class ReviewEntity {
     private LocalDateTime createDate;
 
     private LocalDateTime updateDate;
+
+    public static Review toDto(ReviewEntity entity) {
+        return Review.builder()
+                .reviewId(entity.getReviewId())
+                .laundryId(entity.getLaundryId())
+                .writerId(entity.getWriterId())
+                .rating(entity.getRating())
+                .contents(entity.getContents())
+                .visitDate(entity.getVisitDate())
+                .createDate(entity.getCreateDate())
+                .updateDate(entity.getUpdateDate())
+                .build();
+    }
 
 }

--- a/src/main/java/com/coders/laundry/domain/exceptions/ResourceAlreadyExistsException.java
+++ b/src/main/java/com/coders/laundry/domain/exceptions/ResourceAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.coders.laundry.domain.exceptions;
+
+public class ResourceAlreadyExistsException extends RuntimeException {
+
+    public ResourceAlreadyExistsException(String resourceType) {
+        super(String.format("[%s] is Already exists.", resourceType));
+    }
+
+}

--- a/src/main/java/com/coders/laundry/dto/Laundry.java
+++ b/src/main/java/com/coders/laundry/dto/Laundry.java
@@ -1,0 +1,28 @@
+package com.coders.laundry.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Laundry {
+
+    private int laundryId;
+
+    private String name;
+
+    private String jibunAddress;
+
+    private String jibunAddressDetail;
+
+    private String doroAddress;
+
+    private String doroAddressDetail;
+
+    private double latitude;
+
+    private double longitude;
+
+    private boolean partnership;
+
+}

--- a/src/main/java/com/coders/laundry/dto/ReviewUploadRequest.java
+++ b/src/main/java/com/coders/laundry/dto/ReviewUploadRequest.java
@@ -6,9 +6,7 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import javax.validation.constraints.*;
 import java.time.LocalDate;
 
 @Builder
@@ -30,6 +28,7 @@ public class ReviewUploadRequest {
     private String contents;
 
     @NotNull
+    @PastOrPresent
     @JsonFormat(pattern = "yyyyMMdd")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE, pattern = "yyyyMMdd")
     private LocalDate visitDate;

--- a/src/main/java/com/coders/laundry/dto/ReviewUploadRequest.java
+++ b/src/main/java/com/coders/laundry/dto/ReviewUploadRequest.java
@@ -1,10 +1,7 @@
 package com.coders.laundry.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -16,6 +13,7 @@ import java.time.LocalDate;
 
 @Builder
 @Getter
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewUploadRequest {

--- a/src/main/java/com/coders/laundry/dto/ReviewUploadRequest.java
+++ b/src/main/java/com/coders/laundry/dto/ReviewUploadRequest.java
@@ -9,7 +9,9 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import java.time.LocalDate;
 
 @Builder
@@ -19,15 +21,17 @@ import java.time.LocalDate;
 public class ReviewUploadRequest {
 
     @NotNull
+    @Positive
     private Integer laundryId;
 
     @Range(min = 1L, max = 5L)
     private int rating;
 
-    @NotNull
+    @NotBlank
     @Length(min = 5, max = 300)
     private String contents;
 
+    @NotNull
     @JsonFormat(pattern = "yyyyMMdd")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE, pattern = "yyyyMMdd")
     private LocalDate visitDate;

--- a/src/main/java/com/coders/laundry/dto/ReviewUploadRequest.java
+++ b/src/main/java/com/coders/laundry/dto/ReviewUploadRequest.java
@@ -1,0 +1,35 @@
+package com.coders.laundry.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewUploadRequest {
+
+    @NotNull
+    private Integer laundryId;
+
+    @Range(min = 1L, max = 5L)
+    private int rating;
+
+    @NotNull
+    @Length(min = 5, max = 300)
+    private String contents;
+
+    @JsonFormat(pattern = "yyyyMMdd")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE, pattern = "yyyyMMdd")
+    private LocalDate visitDate;
+
+}

--- a/src/main/java/com/coders/laundry/repository/ReviewRepository.java
+++ b/src/main/java/com/coders/laundry/repository/ReviewRepository.java
@@ -11,8 +11,11 @@ public interface ReviewRepository {
 
     int insert(ReviewEntity review);
 
-    ReviewEntity selectById(@Param("reviewId") int reviewId);
+    ReviewEntity selectById(@Param("reviewId") Integer reviewId);
 
-    int deleteById(@Param("reviewId") int reviewId);
+    int deleteById(@Param("reviewId") Integer reviewId);
+
+    ReviewEntity selectByLaundryIdAndWriterId(@Param("laundryId") Integer laundryId,
+                                              @Param("writerId") Integer writerId);
 
 }

--- a/src/main/java/com/coders/laundry/repository/ReviewRepository.java
+++ b/src/main/java/com/coders/laundry/repository/ReviewRepository.java
@@ -5,6 +5,8 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Mapper
 @Repository
 public interface ReviewRepository {
@@ -17,5 +19,7 @@ public interface ReviewRepository {
 
     ReviewEntity selectByLaundryIdAndWriterId(@Param("laundryId") Integer laundryId,
                                               @Param("writerId") Integer writerId);
+
+    List<ReviewEntity> selectAllByLaundryId(@Param("laundryId") Integer laundryId);
 
 }

--- a/src/main/java/com/coders/laundry/repository/ReviewRepository.java
+++ b/src/main/java/com/coders/laundry/repository/ReviewRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Mapper
@@ -17,8 +18,9 @@ public interface ReviewRepository {
 
     int deleteById(@Param("reviewId") Integer reviewId);
 
-    ReviewEntity selectByLaundryIdAndWriterId(@Param("laundryId") Integer laundryId,
-                                              @Param("writerId") Integer writerId);
+    ReviewEntity selectByLaundryIdAndWriterIdAndVisitDate(@Param("laundryId") Integer laundryId,
+                                                          @Param("writerId") Integer writerId,
+                                                          @Param("visitDate") LocalDate visitDate);
 
     List<ReviewEntity> selectAllByLaundryId(@Param("laundryId") Integer laundryId);
 

--- a/src/main/java/com/coders/laundry/service/LaundryFindService.java
+++ b/src/main/java/com/coders/laundry/service/LaundryFindService.java
@@ -1,17 +1,17 @@
 package com.coders.laundry.service;
 
 import com.coders.laundry.domain.entity.LaundryEntity;
+import com.coders.laundry.dto.Laundry;
 import com.coders.laundry.dto.LocationSearch;
 import com.coders.laundry.dto.Pageable;
 import com.coders.laundry.dto.SearchedLaundry;
 import com.coders.laundry.repository.LaundryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import javax.validation.constraints.NotNull;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +19,13 @@ public class LaundryFindService {
 
     private final LaundryRepository laundryRepository;
 
+    @Transactional(readOnly = true)
+    public Optional<Laundry> findById(@NotNull Integer laundryId) {
+        LaundryEntity entity = laundryRepository.selectById(laundryId);
+        return Optional.ofNullable(LaundryEntity.toDto(entity));
+    }
+
+    @Transactional(readOnly = true)
     public int findCount(String keyword,
                          LocationSearch locationSearch,
                          String searchMode) {
@@ -32,6 +39,7 @@ public class LaundryFindService {
         }
     }
 
+    @Transactional(readOnly = true)
     public List<SearchedLaundry> search(int memberId,
                                         String keyword,
                                         LocationSearch locationSearch,
@@ -56,7 +64,7 @@ public class LaundryFindService {
             case "point" -> list.sort(Comparator.comparing(LaundryEntity::getRatingPoint));
         }
 
-        if(sortType.equals("desc")) {
+        if (sortType.equals("desc")) {
             Collections.reverse(list);
         }
 

--- a/src/main/java/com/coders/laundry/service/ReviewService.java
+++ b/src/main/java/com/coders/laundry/service/ReviewService.java
@@ -1,0 +1,48 @@
+package com.coders.laundry.service;
+
+import com.coders.laundry.domain.entity.ReviewEntity;
+import com.coders.laundry.domain.exceptions.ResourceAlreadyExistsException;
+import com.coders.laundry.dto.Review;
+import com.coders.laundry.dto.ReviewUploadRequest;
+import com.coders.laundry.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Service
+@Validated
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    @Validated
+    public Review save(@NotNull Integer writerId, @Valid ReviewUploadRequest request) {
+        // TODO Validate the existence of members
+
+        ReviewEntity existedReview = reviewRepository
+                .selectByLaundryIdAndWriterId(request.getLaundryId(), writerId);
+        if (existedReview != null) {
+            throw new ResourceAlreadyExistsException("Review");
+        }
+
+        ReviewEntity entity = ReviewEntity.builder()
+                .laundryId(request.getLaundryId())
+                .writerId(writerId)
+                .rating(request.getRating())
+                .contents(request.getContents())
+                .visitDate(request.getVisitDate())
+                .build();
+
+        reviewRepository.insert(entity);
+
+        ReviewEntity created = reviewRepository.selectById(entity.getReviewId());
+        return ReviewEntity.toDto(created);
+    }
+
+}

--- a/src/main/java/com/coders/laundry/service/ReviewService.java
+++ b/src/main/java/com/coders/laundry/service/ReviewService.java
@@ -43,7 +43,7 @@ public class ReviewService {
         // TODO Validate the existence of members
         laundryFindService.findById(request.getLaundryId()).orElseThrow();
         ReviewEntity existedReview = reviewRepository
-                .selectByLaundryIdAndWriterId(request.getLaundryId(), writerId);
+                .selectByLaundryIdAndWriterIdAndVisitDate(request.getLaundryId(), writerId, request.getVisitDate());
         if (existedReview != null) {
             throw new ResourceAlreadyExistsException("Review");
         }

--- a/src/main/java/com/coders/laundry/service/ReviewService.java
+++ b/src/main/java/com/coders/laundry/service/ReviewService.java
@@ -12,6 +12,9 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @Service
 @Validated
@@ -20,9 +23,20 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
 
-    @Transactional
     @Validated
-    public Review save(@NotNull Integer writerId, @Valid ReviewUploadRequest request) {
+    @Transactional(readOnly = true)
+    public List<Review> findAllByLaundryId(@NotNull Integer laundryId) {
+        // TODO Validate the existence of laundry by id
+        List<ReviewEntity> entities = reviewRepository.selectAllByLaundryId(laundryId);
+        return entities
+                .stream()
+                .map(ReviewEntity::toDto)
+                .collect(toList());
+    }
+
+    @Validated
+    @Transactional
+    public Review upload(@NotNull Integer writerId, @Valid ReviewUploadRequest request) {
         // TODO Validate the existence of members
 
         ReviewEntity existedReview = reviewRepository

--- a/src/main/java/com/coders/laundry/service/ReviewService.java
+++ b/src/main/java/com/coders/laundry/service/ReviewService.java
@@ -23,10 +23,13 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
 
+    private final LaundryFindService laundryFindService;
+
     @Validated
     @Transactional(readOnly = true)
     public List<Review> findAllByLaundryId(@NotNull Integer laundryId) {
-        // TODO Validate the existence of laundry by id
+        // TODO Throw EntityNotFoundException after defining global exception handler
+        laundryFindService.findById(laundryId).orElseThrow();
         List<ReviewEntity> entities = reviewRepository.selectAllByLaundryId(laundryId);
         return entities
                 .stream()
@@ -38,7 +41,7 @@ public class ReviewService {
     @Transactional
     public Review upload(@NotNull Integer writerId, @Valid ReviewUploadRequest request) {
         // TODO Validate the existence of members
-
+        laundryFindService.findById(request.getLaundryId()).orElseThrow();
         ReviewEntity existedReview = reviewRepository
                 .selectByLaundryIdAndWriterId(request.getLaundryId(), writerId);
         if (existedReview != null) {

--- a/src/main/resources/mapper/reviewMapper.xml
+++ b/src/main/resources/mapper/reviewMapper.xml
@@ -40,4 +40,12 @@
                AND writer_id = #{writerId};
     </select>
 
+    <select id="selectAllByLaundryId"
+            resultType="ReviewEntity">
+        SELECT review_id, laundry_id, writer_id, rating,
+               contents, visit_date, create_date, update_date
+          FROM review
+         WHERE laundry_id = #{laundryId};
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/reviewMapper.xml
+++ b/src/main/resources/mapper/reviewMapper.xml
@@ -31,13 +31,14 @@
          WHERE review_id = #{reviewId};
     </delete>
 
-    <select id="selectByLaundryIdAndWriterId"
+    <select id="selectByLaundryIdAndWriterIdAndVisitDate"
             resultType="ReviewEntity">
         SELECT review_id, laundry_id, writer_id, rating,
                contents, visit_date, create_date, update_date
           FROM review
          WHERE laundry_id = #{laundryId}
-               AND writer_id = #{writerId};
+               AND writer_id = #{writerId}
+               AND visit_date = #{visitDate};
     </select>
 
     <select id="selectAllByLaundryId"

--- a/src/main/resources/mapper/reviewMapper.xml
+++ b/src/main/resources/mapper/reviewMapper.xml
@@ -5,8 +5,8 @@
     <insert id="insert"
             parameterType="ReviewEntity"
             useGeneratedKeys="true"
-            keyProperty="reviewId"
-            keyColumn="review_id">
+            keyProperty="reviewId,createDate,updateDate"
+            keyColumn="review_id,create_date,update_date">
         INSERT INTO review (
                laundry_id, writer_id, rating, contents, visit_date
                )
@@ -15,7 +15,8 @@
                );
     </insert>
 
-    <select id="selectById" parameterType="int"
+    <select id="selectById"
+            parameterType="Integer"
             resultType="ReviewEntity">
         SELECT review_id, laundry_id, writer_id, rating,
                contents, visit_date, create_date, update_date
@@ -24,10 +25,19 @@
     </select>
 
     <delete id="deleteById"
-            parameterType="int">
+            parameterType="Integer">
         DELETE
           FROM review
          WHERE review_id = #{reviewId};
     </delete>
+
+    <select id="selectByLaundryIdAndWriterId"
+            resultType="ReviewEntity">
+        SELECT review_id, laundry_id, writer_id, rating,
+               contents, visit_date, create_date, update_date
+          FROM review
+         WHERE laundry_id = #{laundryId}
+               AND writer_id = #{writerId};
+    </select>
 
 </mapper>

--- a/src/test/java/com/coders/laundry/controller/ReviewControllerTest.java
+++ b/src/test/java/com/coders/laundry/controller/ReviewControllerTest.java
@@ -1,0 +1,180 @@
+package com.coders.laundry.controller;
+
+import com.coders.laundry.dto.Review;
+import com.coders.laundry.dto.ReviewUploadRequest;
+import com.coders.laundry.service.ReviewService;
+import com.coders.laundry.service.TokenManagerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("dev")
+@WebMvcTest(ReviewController.class)
+@ExtendWith(MockitoExtension.class)
+class ReviewControllerTest {
+
+    @MockBean
+    private ReviewService reviewService;
+
+    @MockBean
+    private TokenManagerService tokenManagerService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void findLaundryReviewsByLaundryId() throws Exception {
+        // Arrange
+        Integer laundryId = 1231245;
+        LocalDateTime now = LocalDateTime.now();
+        Review review = Review.builder()
+                .reviewId(1)
+                .laundryId(laundryId)
+                .rating(5)
+                .contents("리뷰 내용")
+                .visitDate(LocalDate.of(2022, 9, 23))
+                .createDate(now)
+                .updateDate(now)
+                .build();
+        List<Review> foundReviews = List.of(review);
+        when(reviewService.findAllByLaundryId(laundryId)).thenReturn(foundReviews);
+
+        // Act
+        ResultActions actions = mockMvc.perform(get("/api/laundries/{laundryId}/reviews", laundryId)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("laundryId", String.valueOf(laundryId))
+        );
+
+        // Assert
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.*", hasSize(foundReviews.size())))
+                .andExpect(jsonPath("$[0].laundryId").exists())
+                .andDo(print());
+    }
+
+    @Test
+    void findLaundryReviewsByLaundryId_WhenTargetLaundryNotFound() throws Exception {
+        // Arrange
+        Integer laundryId = 1231245;
+        when(reviewService.findAllByLaundryId(laundryId)).thenThrow(new RuntimeException());
+
+        // Act
+        ResultActions actions = mockMvc.perform(get("/api/laundries/{laundryId}/reviews", laundryId)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("laundryId", String.valueOf(laundryId))
+        );
+
+        // Assert
+        actions.andExpect(status().isNotFound())
+                .andDo(print());
+    }
+
+    @Test
+    void uploadLaundryReview() throws Exception {
+        // Arrange
+        String token = "Bearer test token";
+        ReviewUploadRequest request = createReviewUploadRequest();
+        Integer writerId = 1244125;
+
+        LocalDateTime now = LocalDateTime.now();
+        Review createdReview = Review.builder()
+                .reviewId(12413235)
+                .writerId(writerId)
+                .laundryId(request.getLaundryId())
+                .visitDate(request.getVisitDate())
+                .contents(request.getContents())
+                .rating(request.getRating())
+                .createDate(now)
+                .updateDate(now)
+                .build();
+
+        when(tokenManagerService.verify(token)).thenReturn(true);
+        when(tokenManagerService.findMemberId(token)).thenReturn(writerId);
+        when(reviewService.upload(writerId, request)).thenReturn(createdReview);
+
+        // Act
+        ResultActions actions = mockMvc.perform(post("/api/laundries/{laundryId}/reviews", request.getLaundryId())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // Assert
+        actions.andExpect(status().isCreated())
+                .andExpect(header().exists(HttpHeaders.LOCATION))
+                .andExpect(jsonPath("reviewId").value(createdReview.getReviewId()))
+                .andDo(print());
+    }
+
+    @Test
+    void uploadLaundryReview_TokenIsNotVerified() throws Exception {
+        // Arrange
+        String token = "Bearer test token";
+        ReviewUploadRequest request = createReviewUploadRequest();
+
+        when(tokenManagerService.verify(token)).thenReturn(false);
+
+        // Act
+        ResultActions actions = mockMvc.perform(post("/api/laundries/{laundryId}/reviews", request.getLaundryId())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // Assert
+        actions.andExpect(status().isUnauthorized()).andDo(print());
+    }
+
+    @Test
+    void uploadLaundryReview_WhenPathVariableLaundryIdIsNotMatchedWithRequest() throws Exception {
+        // Arrange
+        String token = "Bearer test token";
+        ReviewUploadRequest request = createReviewUploadRequest();
+
+        when(tokenManagerService.verify(token)).thenReturn(true);
+        when(reviewService.findAllByLaundryId(request.getLaundryId())).thenThrow(RuntimeException.class);
+
+        // Act
+        ResultActions actions = mockMvc.perform(post("/api/laundries/{laundryId}/reviews", request.getLaundryId() + 1)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // Assert
+        actions.andExpect(status().isBadRequest()).andDo(print());
+    }
+
+    private ReviewUploadRequest createReviewUploadRequest() {
+        return ReviewUploadRequest.builder()
+                .laundryId(1213)
+                .visitDate(LocalDate.of(2022, 9, 2))
+                .contents("테스트 리뷰 내용")
+                .rating(2)
+                .build();
+    }
+
+}

--- a/src/test/java/com/coders/laundry/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/coders/laundry/repository/ReviewRepositoryTest.java
@@ -87,8 +87,11 @@ class ReviewRepositoryTest {
         ReviewEntity entity = insertReviewEntity(1, 1);
 
         // Act
-        ReviewEntity result = reviewRepository
-                .selectByLaundryIdAndWriterId(entity.getLaundryId(), entity.getWriterId());
+        ReviewEntity result = reviewRepository.selectByLaundryIdAndWriterIdAndVisitDate(
+                entity.getLaundryId(),
+                entity.getWriterId(),
+                entity.getVisitDate()
+        );
 
         // Assert
         assertNotNull(result);

--- a/src/test/java/com/coders/laundry/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/coders/laundry/repository/ReviewRepositoryTest.java
@@ -64,8 +64,8 @@ class ReviewRepositoryTest {
         assertEquals(entity.getContents(), result.getContents());
         assertEquals(entity.getRating(), result.getRating());
         assertEquals(entity.getVisitDate(), result.getVisitDate());
-        assertNotNull(result.getCreateDate());
-        assertNotNull(result.getUpdateDate());
+        assertEquals(entity.getCreateDate(), result.getCreateDate());
+        assertEquals(entity.getUpdateDate(), result.getUpdateDate());
     }
 
     @Test
@@ -86,6 +86,35 @@ class ReviewRepositoryTest {
 
         // Assert
         assertEquals(1, result);
+    }
+
+    @Test
+    void selectByLaundryIdAndWriterId() {
+        // Arrange
+        ReviewEntity entity = ReviewEntity.builder()
+                .laundryId(1)
+                .writerId(1)
+                .contents("이 빨래방은 정말.....")
+                .rating(5)
+                .visitDate(LocalDate.of(2022, 9, 6))
+                .build();
+
+        reviewRepository.insert(entity);
+
+        // Act
+        ReviewEntity result = reviewRepository
+                .selectByLaundryIdAndWriterId(entity.getLaundryId(), entity.getWriterId());
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(entity.getReviewId(), result.getReviewId());
+        assertEquals(entity.getLaundryId(), result.getLaundryId());
+        assertEquals(entity.getWriterId(), result.getWriterId());
+        assertEquals(entity.getContents(), result.getContents());
+        assertEquals(entity.getRating(), result.getRating());
+        assertEquals(entity.getVisitDate(), result.getVisitDate());
+        assertEquals(entity.getCreateDate(), result.getCreateDate());
+        assertEquals(entity.getUpdateDate(), result.getUpdateDate());
     }
 
 }

--- a/src/test/java/com/coders/laundry/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/coders/laundry/repository/ReviewRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,15 +44,7 @@ class ReviewRepositoryTest {
     @Test
     void selectById() {
         // Arrange
-        ReviewEntity entity = ReviewEntity.builder()
-                .laundryId(1)
-                .writerId(1)
-                .contents("이 빨래방은 정말.....")
-                .rating(5)
-                .visitDate(LocalDate.of(2022, 9, 6))
-                .build();
-
-        reviewRepository.insert(entity);
+        ReviewEntity entity = insertReviewEntity(1, 1);
 
         // Act
         ReviewEntity result = reviewRepository.selectById(entity.getReviewId());
@@ -91,15 +84,7 @@ class ReviewRepositoryTest {
     @Test
     void selectByLaundryIdAndWriterId() {
         // Arrange
-        ReviewEntity entity = ReviewEntity.builder()
-                .laundryId(1)
-                .writerId(1)
-                .contents("이 빨래방은 정말.....")
-                .rating(5)
-                .visitDate(LocalDate.of(2022, 9, 6))
-                .build();
-
-        reviewRepository.insert(entity);
+        ReviewEntity entity = insertReviewEntity(1, 1);
 
         // Act
         ReviewEntity result = reviewRepository
@@ -115,6 +100,41 @@ class ReviewRepositoryTest {
         assertEquals(entity.getVisitDate(), result.getVisitDate());
         assertEquals(entity.getCreateDate(), result.getCreateDate());
         assertEquals(entity.getUpdateDate(), result.getUpdateDate());
+    }
+
+    @Test
+    void selectAllByLaundryId() {
+        // Arrange
+        int reviewCount = 10;
+        Integer laundryId = 2;
+        for (int i = 0; i < reviewCount; i++) {
+            insertReviewEntity(laundryId, i + 1);
+        }
+
+        // Act
+        List<ReviewEntity> result = reviewRepository.selectAllByLaundryId(laundryId);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(reviewCount, result.size());
+        for (ReviewEntity reviewEntity : result) {
+            assertEquals(laundryId, reviewEntity.getLaundryId());
+        }
+    }
+
+    private ReviewEntity insertReviewEntity(Integer laundryId, Integer writerId) {
+        LocalDate visitDate = LocalDate.now();
+        ReviewEntity entity = ReviewEntity.builder()
+                .laundryId(laundryId)
+                .writerId(writerId)
+                .contents("testContents")
+                .rating(5)
+                .visitDate(visitDate)
+                .build();
+
+        reviewRepository.insert(entity);
+
+        return entity;
     }
 
 }

--- a/src/test/java/com/coders/laundry/service/LaundryFindServiceTest.java
+++ b/src/test/java/com/coders/laundry/service/LaundryFindServiceTest.java
@@ -1,36 +1,60 @@
 package com.coders.laundry.service;
 
 import com.coders.laundry.domain.entity.LaundryEntity;
-import com.coders.laundry.dto.LocationSearch;
-import com.coders.laundry.dto.Pageable;
-import com.coders.laundry.dto.Point;
-import com.coders.laundry.dto.SearchedLaundry;
+import com.coders.laundry.dto.*;
 import com.coders.laundry.repository.LaundryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@ActiveProfiles("dev")
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
 class LaundryFindServiceTest {
 
     private LaundryFindService laundryFindService;
 
+    @Mock
     private LaundryRepository laundryRepository;
 
     @BeforeEach
     public void setup() {
-        laundryRepository = mock(LaundryRepository.class);
         laundryFindService = new LaundryFindService(laundryRepository);
+    }
+
+    @Test
+    void findById_WhenLaundryNotFound() {
+        // Arrange
+        int laundryId = 123;
+        when(laundryRepository.selectById(laundryId)).thenReturn(null);
+
+        // Act
+        Optional<Laundry> result = laundryFindService.findById(laundryId);
+
+        // Assert
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void findById_WhenLaundryExists() {
+        // Arrange
+        int laundryId = 123;
+        LaundryEntity laundry = LaundryEntity.builder().laundryId(laundryId).build();
+        when(laundryRepository.selectById(laundryId)).thenReturn(laundry);
+
+        // Act
+        Optional<Laundry> result = laundryFindService.findById(laundryId);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(laundryId, result.get().getLaundryId());
     }
 
     @Test

--- a/src/test/java/com/coders/laundry/service/ReviewServiceTest.java
+++ b/src/test/java/com/coders/laundry/service/ReviewServiceTest.java
@@ -90,7 +90,11 @@ class ReviewServiceTest {
 
         int createdReviewId = 10;
         LocalDateTime createdAt = LocalDateTime.now();
-        when(reviewRepository.selectByLaundryIdAndWriterId(request.getLaundryId(), writerId)).thenReturn(null);
+        when(reviewRepository.selectByLaundryIdAndWriterIdAndVisitDate(
+                request.getLaundryId(),
+                writerId,
+                request.getVisitDate())
+        ).thenReturn(null);
         when(reviewRepository.insert(entity)).thenAnswer(invocation -> {
             Object[] arguments = invocation.getArguments();
             ReviewEntity argEntity = (ReviewEntity) arguments[0];
@@ -173,8 +177,11 @@ class ReviewServiceTest {
 
         Laundry laundry = createReviewTargetLaundry(124);
         when(laundryFindService.findById(request.getLaundryId())).thenReturn(Optional.of(laundry));
-        when(reviewRepository.selectByLaundryIdAndWriterId(request.getLaundryId(), writerId))
-                .thenReturn(exists);
+        when(reviewRepository.selectByLaundryIdAndWriterIdAndVisitDate(
+                request.getLaundryId(),
+                writerId,
+                request.getVisitDate())
+        ).thenReturn(exists);
 
         // Act & Assert
         assertThrows(ResourceAlreadyExistsException.class, () -> reviewService.upload(writerId, request));

--- a/src/test/java/com/coders/laundry/service/ReviewServiceTest.java
+++ b/src/test/java/com/coders/laundry/service/ReviewServiceTest.java
@@ -1,0 +1,124 @@
+package com.coders.laundry.service;
+
+import com.coders.laundry.domain.entity.ReviewEntity;
+import com.coders.laundry.domain.exceptions.ResourceAlreadyExistsException;
+import com.coders.laundry.dto.Review;
+import com.coders.laundry.dto.ReviewUploadRequest;
+import com.coders.laundry.repository.ReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+class ReviewServiceTest {
+
+    private ReviewService reviewService;
+
+    private ReviewRepository reviewRepository;
+
+    @BeforeEach
+    public void setup() {
+        reviewRepository = mock(ReviewRepository.class);
+        reviewService = new ReviewService(reviewRepository);
+    }
+
+    @Test
+    void save() {
+        // Arrange
+        Integer writerId = 1;
+        ReviewUploadRequest request = ReviewUploadRequest.builder()
+                .laundryId(1)
+                .rating(5)
+                .contents("리뷰 내용입니다.")
+                .visitDate(LocalDate.of(2022, 9, 6))
+                .build();
+
+        ReviewEntity entity = ReviewEntity.builder()
+                .laundryId(request.getLaundryId())
+                .writerId(writerId)
+                .rating(request.getRating())
+                .contents(request.getContents())
+                .visitDate(request.getVisitDate())
+                .build();
+
+        int createdReviewId = 10;
+        LocalDateTime createdAt = LocalDateTime.now();
+        when(reviewRepository.selectByLaundryIdAndWriterId(request.getLaundryId(), writerId)).thenReturn(null);
+        when(reviewRepository.insert(entity)).thenAnswer(invocation -> {
+            Object[] arguments = invocation.getArguments();
+            ReviewEntity argEntity = (ReviewEntity) arguments[0];
+            argEntity.setReviewId(createdReviewId);
+            argEntity.setCreateDate(createdAt);
+            argEntity.setUpdateDate(createdAt);
+            return 1;
+        });
+
+        ReviewEntity created = ReviewEntity.builder()
+                .reviewId(createdReviewId)
+                .laundryId(request.getLaundryId())
+                .writerId(writerId)
+                .rating(request.getRating())
+                .contents(request.getContents())
+                .visitDate(request.getVisitDate())
+                .createDate(createdAt)
+                .updateDate(createdAt)
+                .build();
+
+        when(reviewRepository.selectById(createdReviewId)).thenReturn(created);
+
+        // Act
+        Review result = reviewService.save(writerId, request);
+
+        // Assert
+        assertNotNull(result.getReviewId());
+        assertEquals(request.getLaundryId(), result.getLaundryId());
+        assertEquals(writerId, result.getWriterId());
+        assertEquals(request.getRating(), result.getRating());
+        assertEquals(request.getContents(), result.getContents());
+        assertEquals(request.getVisitDate(), result.getVisitDate());
+        assertNotNull(result.getCreateDate());
+        assertNotNull(result.getUpdateDate());
+    }
+
+    @Test
+    void save_ResourceAlreadyExistsException() {
+        // Arrange
+        Integer writerId = 1;
+        ReviewUploadRequest request = ReviewUploadRequest.builder()
+                .laundryId(1)
+                .rating(5)
+                .contents("리뷰 내용입니다.")
+                .visitDate(LocalDate.of(2022, 9, 6))
+                .build();
+
+        LocalDateTime createdAt = LocalDateTime.now();
+        ReviewEntity exists = ReviewEntity.builder()
+                .reviewId(1)
+                .laundryId(request.getLaundryId())
+                .writerId(writerId)
+                .rating(request.getRating())
+                .contents(request.getContents())
+                .visitDate(request.getVisitDate())
+                .createDate(createdAt)
+                .updateDate(createdAt)
+                .build();
+
+        when(reviewRepository.selectByLaundryIdAndWriterId(request.getLaundryId(), writerId))
+                .thenReturn(exists);
+
+        // Act & Assert
+        assertThrows(ResourceAlreadyExistsException.class, () -> {
+            reviewService.save(writerId, request);
+        });
+    }
+
+}

--- a/src/test/java/com/coders/laundry/service/ReviewServiceTest.java
+++ b/src/test/java/com/coders/laundry/service/ReviewServiceTest.java
@@ -13,6 +13,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -32,7 +35,23 @@ class ReviewServiceTest {
     }
 
     @Test
-    void save() {
+    void findAllByLaundryId() {
+        // Arrange
+        int reviewCount = 5;
+        Integer laundryId = 1;
+        List<ReviewEntity> reviews = getReviewEntityDummy(reviewCount, laundryId, 1);
+        when(reviewRepository.selectAllByLaundryId(laundryId)).thenReturn(reviews);
+
+        // Act
+        List<Review> result = reviewService.findAllByLaundryId(laundryId);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(reviewCount, result.size());
+    }
+
+    @Test
+    void upload() {
         // Arrange
         Integer writerId = 1;
         ReviewUploadRequest request = ReviewUploadRequest.builder()
@@ -76,7 +95,7 @@ class ReviewServiceTest {
         when(reviewRepository.selectById(createdReviewId)).thenReturn(created);
 
         // Act
-        Review result = reviewService.save(writerId, request);
+        Review result = reviewService.upload(writerId, request);
 
         // Assert
         assertNotNull(result.getReviewId());
@@ -90,7 +109,7 @@ class ReviewServiceTest {
     }
 
     @Test
-    void save_ResourceAlreadyExistsException() {
+    void upload_ResourceAlreadyExistsException() {
         // Arrange
         Integer writerId = 1;
         ReviewUploadRequest request = ReviewUploadRequest.builder()
@@ -117,8 +136,23 @@ class ReviewServiceTest {
 
         // Act & Assert
         assertThrows(ResourceAlreadyExistsException.class, () -> {
-            reviewService.save(writerId, request);
+            reviewService.upload(writerId, request);
         });
     }
 
+    private List<ReviewEntity> getReviewEntityDummy(int dummyCount, Integer laundryId, Integer writerId) {
+        Random random = new Random();
+        List<ReviewEntity> reviews = new ArrayList<>();
+        for (int i = 0; i < dummyCount; i++) {
+            ReviewEntity entity = ReviewEntity.builder()
+                    .laundryId(laundryId)
+                    .writerId(writerId)
+                    .rating(random.nextInt(5))
+                    .contents("testReviewContents")
+                    .visitDate(LocalDate.now())
+                    .build();
+            reviews.add(entity);
+        }
+        return reviews;
+    }
 }


### PR DESCRIPTION
### What's Changed?
- 빨래방 방문 리뷰 API 추가
  - 리뷰 작성 (`POST`, /api/laundries/{laundryId}/reviews)
  - 빨래방별 리뷰 목록 조회 (`GET`, /api/laundries/{laundryId}/reviews)

### Related Issue
- resolved: #74

### To reviewers
- 리뷰는 방문일자별로 하나만 작성할 수 있도록 했습니다.
- 나중에 `LaundryVisitHistory` 테이블 참조해서 실제 방문 후 작성한 리뷰를 구분해야할 것 같아요.
- @dldmldlsy 
  - `memberId`가 현재 유효한지 확인하는 경우가 많을 것 같아서 `memberId` 이용해서 회원을 찾을 수 있는 Service 메서드가 필요할 것 같아요. 

### Docs
- [**API Document** ](https://www.notion.so/9829a75085454c39923226810cca4fd9)